### PR TITLE
Fix Swift Project Manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # OS X
 .DS_Store
-
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -2,19 +2,19 @@
 import PackageDescription
 
 let package = Package(
-    name: "flic2lib",
-    platforms: [
-        .macOS(.v11), .iOS(.v12), .tvOS(.v14)
-    ],
-    products: [
-        .library(
-            name: "flic2lib",
-            targets: ["flic2lib"])
-    ],
-    targets: [
-        .binaryTarget(
-            name: "flic2lib",
-            path: "flic2lib.xcframework"
-        )
-    ]
+  name: "Flic2",
+  platforms: [
+    .macOS(.v11),
+    .iOS(.v12),
+    .tvOS(.v14)
+  ],
+
+  products: [
+    .library(name: "Flic2", targets: ["Flic2", "Flic2XCFramework"]),
+  ],
+
+  targets: [
+    .target(name: "Flic2", dependencies: ["Flic2XCFramework"]),
+    .binaryTarget(name: "Flic2XCFramework", path: "flic2lib.xcframework"),
+  ]
 )

--- a/Sources/Flic2/Dummy.swift
+++ b/Sources/Flic2/Dummy.swift
@@ -1,0 +1,1 @@
+import Foundation


### PR DESCRIPTION
## Description
This PR provides a fix for the Swift Package Manifest for successful integration with any SPM-based project.

## Context
While attempting to integrate flic2lib with our project, we noticed some issues with the Swift Package Manifest that prevented successful integration of the dependency with the iOS project
<img width="1085" alt="Screenshot 2025-04-03 at 10 08 18 am" src="https://github.com/user-attachments/assets/1c9f09aa-b6af-4fd7-8871-1b81e0d6efa9" />

In an attempt to fix the problem, the Swift Package Manifest file was updated to ensure the accessibility of the binary target product by adding a wrapper target on top. This has resolved the problem and resulted in the successful integration of the lib
<img width="1085" alt="Screenshot 2025-04-03 at 10 11 17 am" src="https://github.com/user-attachments/assets/2cfc08c4-cb65-47a2-81fb-832fd3534e3f" />